### PR TITLE
メソッドの引数名をアルファベット順にする

### DIFF
--- a/src/dts-generator.js
+++ b/src/dts-generator.js
@@ -201,11 +201,16 @@ function collectMethods(node) {
       name = prop.key.value;
     }
 
-    for (const param of prop.value.params) {
+    for (let index = 0; index < prop.value.params.length; index++) {
+      const param = prop.value.params[index];
       if (param.type !== 'Identifier') continue;
 
+      // param.nameにはバンドラーによって生成されたランダムな引数名が入っている。
+      // バージョン間で意味のない差分が生じるのを防ぐため、代わりにa-zのアルファベットを使う。
+      const name = 'abcdefghijklmnopqrstuvwxyz'[index]; // 引数の数が26を超えないと仮定
+
       params.push({
-        name: param.name,
+        name,
         type: 'any',
       });
     }


### PR DESCRIPTION
メソッドの引数名をアルファベット順にしてunion.d.tsに意味のない差分が生じるのを防ぎます。
更新されたunion.d.tsも含めたかったのですが、v1.4.1.0（古いバージョン）のいせそうが入手できなかったのでそのままです。